### PR TITLE
Added convergence criteria and re-branched locals

### DIFF
--- a/htsohm/binning.py
+++ b/htsohm/binning.py
@@ -21,9 +21,9 @@ def select_parents(run_id, children_per_generation, generation):
             func.count(Material.id), Material.methane_loading_bin, Material.surface_area_bin,
             Material.void_fraction_bin
         ) \
-        .filter(
-            Material.run_id == run_id).group_by(Material.methane_loading_bin,
-            Material.surface_area_bin, Material.void_fraction_bin
+        .filter(Material.run_id == run_id) \
+        .group_by(
+            Material.methane_loading_bin, Material.surface_area_bin, Material.void_fraction_bin
         ).all()[1:]
     bins = [{"ML" : i[1], "SA" : i[2], "VF" : i[3]} for i in bins_and_counts]
     total = sum([i[0] for i in bins_and_counts])
@@ -42,7 +42,8 @@ def select_parents(run_id, children_per_generation, generation):
         parent_query = session \
             .query(Material.id) \
             .filter(
-                Material.run_id == run_id, Material.methane_loading_bin == parent_bin["ML"],
+                Material.run_id == run_id,
+                Material.methane_loading_bin == parent_bin["ML"],
                 Material.surface_area_bin == parent_bin["SA"],
                 Material.void_fraction_bin == parent_bin["VF"]
             ).all()

--- a/htsohm/binning.py
+++ b/htsohm/binning.py
@@ -32,8 +32,9 @@ def select_parents(run_id, children_per_generation, generation):
 
     ############################################################################
     # A parent-material is selected for each material in the next generation.
-    next_generation = session.query(Material).filter(Material.run_id == run_id,
-        Material.generation == generation).all()
+    next_generation = session \
+        .query(Material) \
+        .filter(Material.run_id == run_id, Material.generation == generation).all()
 
     for child in next_generation:
         # First, the bin is selected...

--- a/htsohm/binning.py
+++ b/htsohm/binning.py
@@ -16,10 +16,15 @@ def select_parents(run_id, children_per_generation, generation):
     is selected, a parent is randomly-selected from those materials within that bin.
     """
     # Each bin is counted...
-    bins_and_counts = session.query(func.count(Material.id), Material.methane_loading_bin,
-        Material.surface_area_bin, Material.void_fraction_bin).filter(
-        Material.run_id == run_id).group_by(Material.methane_loading_bin,
-        Material.surface_area_bin, Material.void_fraction_bin).all()[1:]
+    bins_and_counts = session \
+        .query(
+            func.count(Material.id), Material.methane_loading_bin, Material.surface_area_bin,
+            Material.void_fraction_bin
+        ) \
+        .filter(
+            Material.run_id == run_id).group_by(Material.methane_loading_bin,
+            Material.surface_area_bin, Material.void_fraction_bin
+        ).all()[1:]
     bins = [{"ML" : i[1], "SA" : i[2], "VF" : i[3]} for i in bins_and_counts]
     total = sum([i[0] for i in bins_and_counts])
     # ...then assigned a weight.
@@ -33,10 +38,14 @@ def select_parents(run_id, children_per_generation, generation):
     for child in next_generation:
         # First, the bin is selected...
         parent_bin = np.random.choice(bins, p=weights)
-        potential_parents = [i[0] for i in session.query(Material.id).filter(
-            Material.run_id == run_id, Material.methane_loading_bin == parent_bin["ML"],
-            Material.surface_area_bin == parent_bin["SA"],
-            Material.void_fraction_bin == parent_bin["VF"]).all()]
+        parent_query = session \
+            .query(Material.id) \
+            .filter(
+                Material.run_id == run_id, Material.methane_loading_bin == parent_bin["ML"],
+                Material.surface_area_bin == parent_bin["SA"],
+                Material.void_fraction_bin == parent_bin["VF"]
+            ).all()
+        potential_parents = [i[0] for i in parent_query]
         # ...then a parent is select from the materials in that bin.
         parent_id = np.random.choice(potential_parents)
         child.parent_id = str(parent_id)

--- a/htsohm/binning.py
+++ b/htsohm/binning.py
@@ -1,10 +1,13 @@
+# standard library imports
 import os
-import yaml
-import numpy as np
 
+# related third party imports
+import numpy as np
+import yaml
+
+# local application/library specific imports
 from htsohm.runDB_declarative import Base, Material, session
 from htsohm.utilities import read_config_file
-from htsohm import simulate as sim
 
 def count_bin(run_id, ml_bin, sa_bin, vf_bin):
     """Returns number of materials in a particular bin."""

--- a/htsohm/binning.py
+++ b/htsohm/binning.py
@@ -1,32 +1,9 @@
-# standard library imports
-import os
-
 # related third party imports
 import numpy as np
-import yaml
+from sqlalchemy import func
 
 # local application/library specific imports
 from htsohm.runDB_declarative import Base, Material, session
-from htsohm.utilities import read_config_file
-
-def count_bin(run_id, ml_bin, sa_bin, vf_bin):
-    """Returns number of materials in a particular bin."""
-    bin_count = session.query(Material).filter(Material.run_id == run_id, Material.methane_loading_bin == ml_bin,
-        Material.surface_area_bin == sa_bin, Material.void_fraction_bin == vf_bin,
-        Material.dummy_test_result.in_(('none', 'pass'))).count()
-    return bin_count
-
-def count_all(run_id):
-    """Returns an array containing the number of materials in every bin."""
-    config = read_config_file(run_id)
-    bins = config["number-of-bins"]
-    all_counts = np.zeros([bins, bins, bins])
-    for i in range(bins):
-        for j in range(bins):
-            for k in range(bins):
-                bin_count = count_bin(run_id, i, j, k)
-                all_counts[i,j,k] = bin_count
-    return all_counts
 
 def select_parents(run_id, children_per_generation, generation):
     """Use bin-counts to preferentially select a list of rare parents.
@@ -36,44 +13,32 @@ def select_parents(run_id, children_per_generation, generation):
     for new materials, because their children are most likely to display unique properties. This
     function first calculates a `weight` for each bin, based on the number of constituent
     materials. These weights affect the probability of selecting a parent from that bin. Once a bin
-    is selected, a parent is randomly-selected from those materials within that bin."""
-
-    # Each bin is counted, then assigned a weight
-    config = read_config_file(run_id)
-    bins = config["number-of-bins"]
-    counts = count_all(run_id)
-    weights = np.zeros([bins, bins, bins])
-    for i in range(bins):
-        for j in range(bins):
-            for k in range(bins):
-                if counts[i,j,k] != 0.:
-                    weights[i,j,k] = counts.sum() / counts[i,j,k]
-    weights = weights / weights.sum()
-
-    ############################################################################
-    # The 3-dimensional list of weights is converted into a 1-dimensional list,
-    # and another 1-dimensional list of material-IDs is also generated.
-    weight_list = []
-    id_list = []
-    for i in range(bins):
-        for j in range(bins):
-            weight_list = np.concatenate([weight_list, weights[i,j,:]])
-            for k in range(bins):
-                bin_ids = []
-                materials = session.query(Material).filter(Material.run_id == run_id, Material.methane_loading_bin == i,
-                    Material.surface_area_bin == j, Material.void_fraction_bin == k,
-                    Material.dummy_test_result.in_(['none', 'pass'])).all()
-                for material in materials:
-                    bin_ids.append(material.id)
-                id_list = id_list + [bin_ids]
+    is selected, a parent is randomly-selected from those materials within that bin.
+    """
+    # Each bin is counted...
+    bins_and_counts = session.query(func.count(Material.id), Material.methane_loading_bin,
+        Material.surface_area_bin, Material.void_fraction_bin).filter(
+        Material.run_id == run_id).group_by(Material.methane_loading_bin,
+        Material.surface_area_bin, Material.void_fraction_bin).all()[1:]
+    bins = [{"ML" : i[1], "SA" : i[2], "VF" : i[3]} for i in bins_and_counts]
+    total = sum([i[0] for i in bins_and_counts])
+    # ...then assigned a weight.
+    weights = [i[0] / float(total) for i in bins_and_counts]
 
     ############################################################################
     # A parent-material is selected for each material in the next generation.
-    next_generation = session.query(Material).filter(Material.run_id == run_id, Material.generation == generation).all()
+    next_generation = session.query(Material).filter(Material.run_id == run_id,
+        Material.generation == generation).all()
 
-    for material in next_generation:
-        parents_list = np.random.choice(id_list, p=weight_list)  # weighted sampling function
-        parent_id = np.random.choice(parents_list)
-        material.parent_id = str(parent_id)
+    for child in next_generation:
+        # First, the bin is selected...
+        parent_bin = np.random.choice(bins, p=weights)
+        potential_parents = [i[0] for i in session.query(Material.id).filter(
+            Material.run_id == run_id, Material.methane_loading_bin == parent_bin["ML"],
+            Material.surface_area_bin == parent_bin["SA"],
+            Material.void_fraction_bin == parent_bin["VF"]).all()]
+        # ...then a parent is select from the materials in that bin.
+        parent_id = np.random.choice(potential_parents)
+        child.parent_id = str(parent_id)
 
     return next_generation

--- a/htsohm/generate.py
+++ b/htsohm/generate.py
@@ -1,10 +1,10 @@
 # standard library imports
-import os
+from functools import reduce
 from math import floor
+import os
 from random import choice, random, randrange, uniform
 
-# it stat third party imports
-from functools import reduce
+# related third party imports
 import numpy as np
 import yaml
 

--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -12,7 +12,7 @@ from htsohm.mutate import create_strength_array, recalculate_strength_array
 from htsohm.mutate import write_children_definition_files
 from htsohm.runDB_declarative import Material, session
 from htsohm.simulate import run_all_simulations, dummy_test
-from htsohm.utilities import write_config_file
+from htsohm.utilities import write_config_file, evaluate_convergence
 
 def init_materials_in_database(run_id, children_per_generation, generation):
     """initialize materials in database with run_id and generation"""
@@ -82,8 +82,8 @@ def htsohm(children_per_generation,    # number of materials per generation
            number_of_atomtypes,        # number of atom-types per material
            strength_0,                 # intial strength parameter
            number_of_bins,             # number of bins for analysis
-           max_generations=20):        # maximum number of generations
-
+           max_generations=20,         # maximum number of generations
+           acceptance_value=0.5):      # desired degree of `convergence`
     ############################################################################
     # write run-configuration file
     run_id = write_config_file(children_per_generation, number_of_atomtypes, strength_0,

--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -100,4 +100,4 @@ def htsohm(children_per_generation,    # number of materials per generation
                 next_generation(run_id, children_per_generation, generation)
                 convergence = evaluate_convergence(run_id)
                 save_convergence(run_id, generation, convergence)
-            print('conergence:\t%s' % convergence)
+            print('convergence:\t%s' % convergence)

--- a/htsohm/mutate.py
+++ b/htsohm/mutate.py
@@ -1,12 +1,13 @@
+# standard library imports
 import os
+from random import random, choice, uniform
 import shutil
+
+# related third party imports
+import numpy as np
 import yaml
 
-import numpy as np
-from random import random, choice, uniform
-
-from htsohm import binning as bng
-from htsohm import simulate as sim
+# local application/library specific imports
 from htsohm.runDB_declarative import session, Material
 from htsohm.utilities import read_config_file, write_force_field, write_cif_file
 from htsohm.utilities import write_mixing_rules

--- a/htsohm/runDB_declarative.py
+++ b/htsohm/runDB_declarative.py
@@ -1,11 +1,12 @@
+# standard library imports
 import os
 import sys
-import yaml
 
 from sqlalchemy import Column, ForeignKey, Integer, String, Float, Boolean
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+import yaml
 
 Base = declarative_base()
 class Material(Base):

--- a/htsohm/simulate.py
+++ b/htsohm/simulate.py
@@ -1,15 +1,17 @@
+# standard library imports
 import os
-import subprocess
 import shlex
 import shutil
+import subprocess
 
+# related third party imports
 import numpy as np
 
-from htsohm.runDB_declarative import Material, session
-from htsohm import binning as bng
+# local application/library specific imports
 from htsohm import helium_void_fraction_simulation
 from htsohm import methane_loading_simulation
 from htsohm import surface_area_simulation
+from htsohm.runDB_declarative import Material, session
 from htsohm.utilities import read_config_file
 
 def get_bins(id, methane_loading, surface_area, void_fraction):

--- a/htsohm/utilities.py
+++ b/htsohm/utilities.py
@@ -1,6 +1,6 @@
 import os
 
-from datetime import datetime
+# related third party imports
 import yaml
 
 def write_config_file(children_per_generation, number_of_atomtypes, strength_0,

--- a/htsohm/utilities.py
+++ b/htsohm/utilities.py
@@ -71,8 +71,12 @@ def read_config_file(run_id):
 
 def evaluate_convergence(run_id):
     '''Counts number of materials in each bin and returns variance of these counts.'''
-    bin_counts = session.query(func.count(Material.id)).filter(Material.run_id == run_id).group_by(
-        Material.methane_loading_bin, Material.surface_area_bin, Material.void_fraction_bin
+    bin_counts = session \
+        .query(
+            func.count(Material.id)).filter(Material.run_id == run_id
+        ) \
+        .group_by(
+            Material.methane_loading_bin, Material.surface_area_bin, Material.void_fraction_bin
         ).all()
     bin_counts = [i[0] for i in bin_counts]    # convert SQLAlchemy result to list
     variance = sqrt( sum([(i - (sum(bin_counts) / len(bin_counts)))**2 for i in bin_counts]) / len(bin_counts))

--- a/htsohm/utilities.py
+++ b/htsohm/utilities.py
@@ -72,9 +72,8 @@ def read_config_file(run_id):
 def evaluate_convergence(run_id):
     '''Counts number of materials in each bin and returns variance of these counts.'''
     bin_counts = session \
-        .query(
-            func.count(Material.id)).filter(Material.run_id == run_id
-        ) \
+        .query(func.count(Material.id)) \
+        .filter(Material.run_id == run_id) \
         .group_by(
             Material.methane_loading_bin, Material.surface_area_bin, Material.void_fraction_bin
         ).all()

--- a/htsohm/utilities.py
+++ b/htsohm/utilities.py
@@ -19,7 +19,7 @@ def write_config_file(children_per_generation, number_of_atomtypes, strength_0,
     """
     run_id = datetime.now().isoformat()
     wd = os.environ['HTSOHM_DIR']      # specify working directory
-    config_file = os.path.join(wd, 'config', run_id + '.yaml')
+    config_file = os.path.join(wd, 'config', run_id + '_conf.yaml')
 
     run_config = {
         "run-id" : run_id,
@@ -44,7 +44,7 @@ def update_config_file(run_id):
     and epsilon).
     """
     wd = os.environ['HTSOHM_DIR']      # specify $HTSOHM_DIR as working directory
-    config_file = os.path.join(wd, 'config', run_id + '.yaml')
+    config_file = os.path.join(wd, 'config', run_id + '_conf.yaml')
     with open(config_file) as file:
         run_config = yaml.load(file)
 
@@ -64,7 +64,7 @@ def update_config_file(run_id):
 
 def read_config_file(run_id):
     wd = os.environ['HTSOHM_DIR']
-    config_file = os.path.join(wd, 'config', run_id + '.yaml')
+    config_file = os.path.join(wd, 'config', run_id + '_conf.yaml')
     with open(config_file) as file:
         config = yaml.load(file)
     return config
@@ -78,6 +78,19 @@ def evaluate_convergence(run_id):
     variance = sqrt( sum([(i - (sum(bin_counts) / len(bin_counts)))**2 for i in bin_counts]) / len(bin_counts))
     return variance
 
+def save_convergence(run_id, generation, variance):
+    wd = os.environ['HTSOHM_DIR']      # specify working directory
+    log_file = os.path.join(wd, 'config', run_id + '_log.yaml')
+    data = {
+        "generation_%s" % generation  : variance
+    }
+    if generation == 0:
+        with open(log_file, "w") as file:
+            yaml.dump(data, file, default_flow_style=False)
+    else:
+        with open(log_file, "a") as file:
+            yaml.dump(data, file, default_flow_style=False)
+   
 def write_cif_file(cif_file, lattice_constants, atom_sites):
     with open(cif_file, "w") as file:
         file.write( 


### PR DESCRIPTION
added function evaluate_convergence(run_id) to utilities.

this function counts the number of materials in every bin for all generations within a particular run, it uses these counts to calculate a variance, our convergence criteria. the function is called in htsohm after each generation. when the convergence is lower than the specified value, no more generations are created and the programs stops.

additionally, bin-counting methods were replaced by sqlalchemy.func expression.
