### PR TITLE
Choose mutation strength method

### DIFF
--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -321,10 +321,10 @@ def calculate_mutation_strength(run_id, generation, mutation_strength_bin):
 
         try:
             fraction_in_parent_bin = calculate_percent_children_in_bin(run_id, generation, mutation_strength_bin)
-            if fraction_in_parent_bin < 0.1:
-                mutation_strength.strength *= 0.5
-            elif fraction_in_parent_bin > 0.5 and mutation_strength.strength <= 0.5:
-                mutation_strength.strength *= 2
+            if fraction_in_parent_bin < 0.1 and mutation_strength.strength - 0.05 > 0:
+                mutation_strength.strength -= 0.05
+            elif fraction_in_parent_bin > 0.5 and mutation_strength.strength + 0.05 < 1:
+                mutation_strength.strength += 0.05
         except ZeroDivisionError:
             print("No prior generation materials in this bin with children.")
 

--- a/htsohm/simulation/gas_adsorption_1.py
+++ b/htsohm/simulation/gas_adsorption_1.py
@@ -21,11 +21,11 @@ def write_raspa_file(filename, uuid, helium_void_fraction=None):
     Writes RASPA input-file.
 
     """
-    simulation_cycles      = config['gas_adsorption_0']['simulation_cycles']
-    initialization_cycles  = config['gas_adsorption_0']['initialization_cycles']
-    external_temperature   = config['gas_adsorption_0']['external_temperature']
-    external_pressure      = config['gas_adsorption_0']['external_pressure']
-    adsorbate              = config['gas_adsorption_0']['adsorbate']
+    simulation_cycles      = config['gas_adsorption_1']['simulation_cycles']
+    initialization_cycles  = config['gas_adsorption_1']['initialization_cycles']
+    external_temperature   = config['gas_adsorption_1']['external_temperature']
+    external_pressure      = config['gas_adsorption_1']['external_pressure']
+    adsorbate              = config['gas_adsorption_1']['adsorbate']
       
     with open(filename, "w") as raspa_input_file:
         raspa_input_file.write(
@@ -110,7 +110,7 @@ def parse_output(output_file):
                 results['ga1_host_adsorbate_cou'] = float(line.split()[7])
             line_counter += 1
 
-    adsorbate = config['gas_adsorption_0']['adsorbate']
+    adsorbate = config['gas_adsorption_1']['adsorbate']
     print(
         "\n%s ADSORPTION\tabsolute\texcess\n" % adsorbate +
         "mol/kg\t\t\t%s\t%s\n" % (results['ga1_absolute_molar_loading'], results['ga1_excess_molar_loading']) +
@@ -136,7 +136,7 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
         results (dict): gas loading simulation results.
 
     """
-    adsorbate             = config['gas_adsorption_0']['adsorbate']
+    adsorbate             = config['gas_adsorption_1']['adsorbate']
     simulation_directory  = config['simulations_directory']
     if simulation_directory == 'HTSOHM':
         htsohm_dir = os.path.dirname(os.path.dirname(htsohm.__file__))

--- a/settings/htsohm.sample.yaml
+++ b/settings/htsohm.sample.yaml
@@ -27,6 +27,7 @@ number_of_atom_types: 4
 initial_mutation_strength: 0.2
 number_of_convergence_bins: 10
 convergence_cutoff_criteria: -0.05
+mutation_strength_method: 'adaptive'
 
 charge_limit: 0.0
 elemental_charge: 0.0001


### PR DESCRIPTION
Added config parameter allowing user to select between a flat or adaptive mutation strength method. The flat method does not save mutation strengths to the database, rather loading a value from the config whenever the mutation strength is needed.