### PR TITLE
Fix for 2 dselection

### DIFF
--- a/hts.py
+++ b/hts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from datetime import datetime
 import os
+from distutils.dir_util import copy_tree
 
 import click
 import yaml
@@ -8,7 +9,8 @@ import RASPA2
 
 import htsohm
 from htsohm.files import load_config_file
-from htsohm.htsohm import worker_run_loop
+from htsohm.htsohm import worker_run_loop, calc_bin
+from htsohm.db import session, Material
 
 @click.group()
 def hts():
@@ -38,6 +40,96 @@ def start(config_path):
     with open(file_name, 'w') as config_file:
         yaml.dump(config, config_file, default_flow_style=False)
     print('Run created with id: %s' % run_id)
+
+@hts.command()
+@click.argument('old_run_id')
+@click.argument('generation')
+@click.argument('config_path',type=click.Path())
+def append(old_run_id, generation, config_path):
+    """Create a new run, appending to previous dataset. Method creates a new
+    run-directory, copying all structure-files from the previous run into this
+    new directory. Then the method creates a new table, copying all records
+    from the previous run, but updating the run_id and assigned bin for each
+    material based on the number of bins specified by the user.
+    
+    Args:
+        old_run_id (str): identification string for run to which new data will
+            be appended.
+        generation (int): last generation to include from the old run.
+        config_path (str): path to run configuration file.
+
+    """
+    # load config, update with new run_id
+    config = load_config_file(config_path)
+    htsohm_dir = os.path.dirname(os.path.dirname(htsohm.__file__))
+    run_id = datetime.now().isoformat()
+    config['run_id'] = run_id
+    config['raspa2_dir'] = os.path.dirname(RASPA2.__file__)
+    config['htsohm_dir'] = htsohm_dir
+    
+    # create run-directory, dump config
+    run_dir = os.path.join(htsohm_dir, run_id)
+    os.makedirs(run_dir, exist_ok=True)
+    file_name = os.path.join(run_dir, 'config.yaml')
+    with open(file_name, 'w') as config_file:
+        yaml.dump(config, config_file, default_flow_style=False)
+    print('Run created with id: %s' % run_id)
+
+    print('Copying data from run : '.format(old_run_id))
+
+    query_filter = [Material.run_id==old_run_id, Material.generation<=generation]
+    id_tuples = session.query(Material.id).filter(*query_filter).all()
+    ids = [e[0] for e in id_tuples]
+
+    # re-calculate structure-property bins for all records, copy to new table
+    properties = config['material_properties']
+
+    for some_id in ids:
+        old_material = session.query(Material).get(some_id)
+        new_material = old_material.clone()
+        new_material.id = None
+        new_material.run_id = run_id
+
+        if 'gas_adsorption_0' in properties and 'gas_adsorption_1' not in properties:
+            new_material.gas_adsorption_bin = calc_bin(
+                    new_material.ga0_absolute_volumetric_loading,
+                    *config['gas_adsorption_0']['limits'],
+                    config['number_of_convergence_bins'])
+
+        if 'gas_adsorption_0' in properties and 'gas_adsorption_1' in properties:
+            new_material.gas_adsorption_bin = calc_bin(
+                    (new_material.ga0_absolute_volumetric_loading - new_material.ga1_absolute_volumetric_loading),
+                    *config['gas_adsorption_1']['limits'],
+                    config['number_of_convergence_bins'])
+
+        if 'helium_void_fraction' in properties:
+            new_material.void_fraction_bin = calc_bin(
+                    new_material.vf_helium_void_fraction,
+                    *config['helium_void_fraction']['limits'],
+                    config['number_of_convergence_bins'])
+        
+        if 'surface_area' in properties:
+            new_material.surface_area_bin = calc_bin(
+                    new_material.sa_volumetric_surface_area,
+                    *config['surface_area']['limits'],
+                    config['number_of_convergence_bins'])
+        
+        session.add(new_material)
+    session.commit()
+
+    # copy structure-data files, updating with new run_id
+    old_pseudo_materials_dir = os.path.join(old_run_id, 'pseudo_materials')
+
+    uuid_tuples = session.query(Material.uuid).filter(*query_filter).all()
+    uuids = [e[0] for e in uuid_tuples]
+    for uuid in uuids:
+        file_path = os.path.join(old_pseudo_materials_dir, '{}.yaml'.format(uuid))
+        with open(file_path) as structure_file:
+            pseudo_material = yaml.load(structure_file)
+        pseudo_material.run_id = run_id
+        pseudo_material.dump()
+
+    print('...copy complete!')
 
 @hts.command()
 @click.argument('run_id')

--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -86,7 +86,7 @@ def select_parent(run_id, max_generation, generation_limit):
     """
     simulations = config['material_properties']
     queries = []
-    if 'gas_adsorption' in simulations:
+    if 'gas_adsorption_0' in simulations or 'gas_adsorption_1' in simulations:
         queries.append( getattr(Material, 'gas_adsorption_bin') )
     if 'surface_area' in simulations:
         queries.append( getattr(Material, 'surface_area_bin') )

--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -321,10 +321,10 @@ def calculate_mutation_strength(run_id, generation, mutation_strength_bin):
 
         try:
             fraction_in_parent_bin = calculate_percent_children_in_bin(run_id, generation, mutation_strength_bin)
-            if fraction_in_parent_bin < 0.1:
-                mutation_strength.strength *= 0.5
-            elif fraction_in_parent_bin > 0.5 and mutation_strength.strength <= 0.5:
-                mutation_strength.strength *= 2
+            if fraction_in_parent_bin < 0.1 and mutation_strength.strength - 0.05 > 0:
+                mutation_strength.strength -= 0.05
+            elif fraction_in_parent_bin > 0.5 and mutation_strength.strength + 0.05 < 1:
+                mutation_strength.strength += 0.05
         except ZeroDivisionError:
             print("No prior generation materials in this bin with children.")
 

--- a/htsohm/simulation/gas_adsorption_1.py
+++ b/htsohm/simulation/gas_adsorption_1.py
@@ -21,11 +21,11 @@ def write_raspa_file(filename, uuid, helium_void_fraction=None):
     Writes RASPA input-file.
 
     """
-    simulation_cycles      = config['gas_adsorption_0']['simulation_cycles']
-    initialization_cycles  = config['gas_adsorption_0']['initialization_cycles']
-    external_temperature   = config['gas_adsorption_0']['external_temperature']
-    external_pressure      = config['gas_adsorption_0']['external_pressure']
-    adsorbate              = config['gas_adsorption_0']['adsorbate']
+    simulation_cycles      = config['gas_adsorption_1']['simulation_cycles']
+    initialization_cycles  = config['gas_adsorption_1']['initialization_cycles']
+    external_temperature   = config['gas_adsorption_1']['external_temperature']
+    external_pressure      = config['gas_adsorption_1']['external_pressure']
+    adsorbate              = config['gas_adsorption_1']['adsorbate']
       
     with open(filename, "w") as raspa_input_file:
         raspa_input_file.write(
@@ -110,7 +110,7 @@ def parse_output(output_file):
                 results['ga1_host_adsorbate_cou'] = float(line.split()[7])
             line_counter += 1
 
-    adsorbate = config['gas_adsorption_0']['adsorbate']
+    adsorbate = config['gas_adsorption_1']['adsorbate']
     print(
         "\n%s ADSORPTION\tabsolute\texcess\n" % adsorbate +
         "mol/kg\t\t\t%s\t%s\n" % (results['ga1_absolute_molar_loading'], results['ga1_excess_molar_loading']) +
@@ -136,7 +136,7 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
         results (dict): gas loading simulation results.
 
     """
-    adsorbate             = config['gas_adsorption_0']['adsorbate']
+    adsorbate             = config['gas_adsorption_1']['adsorbate']
     simulation_directory  = config['simulations_directory']
     if simulation_directory == 'HTSOHM':
         htsohm_dir = os.path.dirname(os.path.dirname(htsohm.__file__))

--- a/settings/htsohm.sample.yaml
+++ b/settings/htsohm.sample.yaml
@@ -27,6 +27,7 @@ number_of_atom_types: 4
 initial_mutation_strength: 0.2
 number_of_convergence_bins: 10
 convergence_cutoff_criteria: -0.05
+mutation_strength_method: 'adaptive'
 
 charge_limit: 0.0
 elemental_charge: 0.0001


### PR DESCRIPTION
Old flag, 'gas_adsorption', used instead of updated ones, 'gas_adsorption_0' and 'gas_adsorption_1'. This bug came from updates allowing for two pressures to be simulated, binning according to the difference between the two. The bug does not affect binning itself, but rather parent selection was done without gas adsorption bin consideration.