### PR TITLE
Pseudomaterial structures database

### DIFF
--- a/htsohm/db/__init__.py
+++ b/htsohm/db/__init__.py
@@ -23,6 +23,9 @@ session = sessionmaker(bind=engine)()
 from htsohm.db.base import Base
 from htsohm.db.material import Material
 from htsohm.db.mutation_strength import MutationStrength
+from htsohm.db.structure import Structure
+from htsohm.db.atom_sites import AtomSites
+from htsohm.db.lennard_jones import LennardJones
 
 # Create tables in the engine, if they don't exist already.
 Base.metadata.create_all(engine)

--- a/htsohm/db/atom_sites.py
+++ b/htsohm/db/atom_sites.py
@@ -1,0 +1,24 @@
+
+import sys
+import uuid
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Float, Boolean
+from sqlalchemy.sql import text
+from sqlalchemy.orm import relationship
+
+from htsohm import config
+from htsohm.db import Base, session, engine
+
+class AtomSites(Base):
+    """    """
+    __tablename__ = 'atom_sites'
+
+    id = Column(Integer, primary_key=True)
+    chemical_id = Column(String(10))
+    x_frac = Column(Float)
+    y_frac = Column(Float)
+    z_frac = Column(Float)
+    charge = Column(Float)
+
+    # relationship with 'structures'
+    structure_id = Column(Integer, ForeignKey('structure.id'))

--- a/htsohm/db/lennard_jones.py
+++ b/htsohm/db/lennard_jones.py
@@ -1,0 +1,28 @@
+
+import sys
+import uuid
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Float, Boolean
+from sqlalchemy.sql import text
+from sqlalchemy.orm import relationship
+
+from htsohm import config
+from htsohm.db import Base, session, engine
+
+class LennardJones(Base):
+    """    """
+    __tablename__ = 'lennard_jones'
+
+    id = Column(Integer, primary_key=True)
+    chemical_id = Column(String(10))
+    sigma = Column(Float)
+    epsilon = Column(Float)
+
+    # relationship with 'structures'
+    structure_id = Column(Integer, ForeignKey('structure.id'))
+
+    def __init__(self, chemical_id=None, sigma=None, epsilon=None):
+        """   """
+        self.chemical_id = chemical_id
+        self.sigma = sigma
+        self.epsilon = epsilon

--- a/htsohm/db/material.py
+++ b/htsohm/db/material.py
@@ -4,9 +4,11 @@ import uuid
 
 from sqlalchemy import Column, ForeignKey, Integer, String, Float, Boolean
 from sqlalchemy.sql import text
+from sqlalchemy.orm import relationship
 
 from htsohm import config
 from htsohm.db import Base, session, engine
+from htsohm.db.structure import Structure
 
 class Material(Base):
     """Declarative class mapping to table storing material/simulation data.
@@ -127,6 +129,8 @@ class Material(Base):
     surface_area_bin = Column(Integer)                        # dimm.
     void_fraction_bin = Column(Integer)                       # dimm.
 
+    # relationships
+    structure = relationship("Structure", uselist=False, back_populates="material")
 
     def __init__(self, run_id=None, ):
         """Init material-row.
@@ -140,6 +144,7 @@ class Material(Base):
         """
         self.uuid = str(uuid.uuid4())
         self.run_id = run_id
+        self.structure = Structure()
 
     @property
     def bin(self):

--- a/htsohm/db/material.py
+++ b/htsohm/db/material.py
@@ -146,6 +146,12 @@ class Material(Base):
         self.run_id = run_id
         self.structure = Structure()
 
+    def clone(self):
+        copy = super(Material, self).clone()
+        if self.structure:
+            copy.structure = self.structure.clone()
+        return copy
+
     @property
     def bin(self):
         """Determine material's structure-property bin.

--- a/htsohm/db/structure.py
+++ b/htsohm/db/structure.py
@@ -43,6 +43,16 @@ class Structure(Base):
         self.atom_sites = atom_sites
         self.lennard_jones = lennard_jones
 
+    def clone(self):
+        copy = super(Structure, self).clone()
+        if self.atom_sites:
+            for atom_site in self.atom_sites:
+                copy.atom_sites.append(atom_site)
+        if self.lennard_jones:
+            for atom_type in self.lennard_jones:
+                copy.lennard_jones.append(atom_type)
+        return copy
+
     @property
     def volume(self):
         """   """

--- a/htsohm/db/structure.py
+++ b/htsohm/db/structure.py
@@ -1,0 +1,49 @@
+
+import sys
+import uuid
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Float, Boolean
+from sqlalchemy.sql import text
+from sqlalchemy.orm import relationship
+
+from htsohm import config
+from htsohm.db import Base, session, engine
+from htsohm.db.atom_sites import AtomSites
+from htsohm.db.lennard_jones import LennardJones
+
+class Structure(Base):
+    """    """
+    __tablename__ = 'structure'
+
+    id = Column(Integer, primary_key=True)
+    lattice_constant_a = Column(Float)
+    lattice_constant_b = Column(Float)
+    lattice_constant_c = Column(Float)
+    
+    # relationship with 'materials'
+    material_id = Column(Integer, ForeignKey('materials.id'))
+    material = relationship("Material", back_populates="structure")
+
+    # relationship with 'atom_sites'
+    atom_sites = relationship("AtomSites")
+
+    # relationship with 'lennard_jones'
+    lennard_jones = relationship("LennardJones")
+
+    def __init__(self,
+            lattice_constant_a=None,
+            lattice_constant_b=None,
+            lattice_constant_c=None,
+            atom_sites=[],
+            lennard_jones=[]):
+        """   """
+        self.lattice_constant_a = lattice_constant_a
+        self.lattice_constant_b = lattice_constant_b
+        self.lattice_constant_c = lattice_constant_c
+        self.atom_sites = atom_sites
+        self.lennard_jones = lennard_jones
+
+    @property
+    def volume(self):
+        """   """
+        return self.lattice_constant_a * self.lattice_constant_b * self.lattice_constant_c

--- a/htsohm/htsohm.py
+++ b/htsohm/htsohm.py
@@ -16,18 +16,6 @@ from htsohm.db import engine, session, Material, MutationStrength, Structure
 from htsohm.material_files import generate_material, mutate_material
 from htsohm import simulation
 
-def clone_material(material):
-    copy = material.clone()
-    if material.structure:
-        copy.structure = material.structure.clone()
-        if material.structure.atom_sites:
-            for atom_site in material.structure.atom_sites:
-                copy.structure.atom_sites.append(atom_site)
-        if material.structure.lennard_jones:
-            for atom_type in material.structure.lennard_jones:
-                copy.structure.lennard_jones.append(atom_type)
-    return copy
-
 def materials_in_generation(run_id, generation):
     """Count number of materials in a generation.
 
@@ -225,7 +213,7 @@ def retest(m_orig, retests, tolerance):
     Updates row in database with total number of retests and results.
 
     """
-    m = clone_material(m_orig)
+    m = m_orig.clone()
 
     run_all_simulations(m)
     print('\n\nRETEST_NUM :\t%s' % m_orig.retest_num)

--- a/htsohm/simulation/gas_adsorption_0.py
+++ b/htsohm/simulation/gas_adsorption_0.py
@@ -124,7 +124,7 @@ def parse_output(output_file):
 
     return results
 
-def run(run_id, pseudo_material, helium_void_fraction=None):
+def run(run_id, material, helium_void_fraction=None):
     """Runs gas loading simulation.
 
     Args:
@@ -145,18 +145,18 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
         path = os.environ['SCRATCH']
     else:
         print('OUTPUT DIRECTORY NOT FOUND.')
-    output_dir = os.path.join(path, 'output_%s_%s' % (pseudo_material.uuid, uuid4()))
+    output_dir = os.path.join(path, 'output_%s_%s' % (material.uuid, uuid4()))
     print('Output directory :\t%s' % output_dir)
     os.makedirs(output_dir, exist_ok=True)
     filename = os.path.join(output_dir, '%s_loading.input' % adsorbate)
-    write_raspa_file(filename, pseudo_material.uuid, helium_void_fraction)
-    write_cif_file(pseudo_material, output_dir)
-    write_mixing_rules(pseudo_material, output_dir)
-    write_pseudo_atoms(pseudo_material, output_dir)
+    write_raspa_file(filename, material.uuid, helium_void_fraction)
+    write_cif_file(material, output_dir)
+    write_mixing_rules(material, output_dir)
+    write_pseudo_atoms(material, output_dir)
     write_force_field(output_dir)
     print("Date :\t%s" % datetime.now().date().isoformat())
     print("Time :\t%s" % datetime.now().time().isoformat())
-    print("Simulating %s loading in %s..." % (adsorbate, pseudo_material.uuid))
+    print("Simulating %s loading in %s..." % (adsorbate, material.uuid))
     while True:
         try:
             subprocess.run(
@@ -165,7 +165,7 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
                 cwd = output_dir
             )
         
-            file_name_part = "output_%s" % (pseudo_material.uuid)
+            file_name_part = "output_%s" % (material.uuid)
             output_subdir = os.path.join(output_dir, 'Output', 'System_0')
             for file in os.listdir(output_subdir):
                 if file_name_part in file:

--- a/htsohm/simulation/gas_adsorption_1.py
+++ b/htsohm/simulation/gas_adsorption_1.py
@@ -124,7 +124,7 @@ def parse_output(output_file):
 
     return results
 
-def run(run_id, pseudo_material, helium_void_fraction=None):
+def run(run_id, material, helium_void_fraction=None):
     """Runs gas loading simulation.
 
     Args:
@@ -145,18 +145,18 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
         path = os.environ['SCRATCH']
     else:
         print('OUTPUT DIRECTORY NOT FOUND.')
-    output_dir = os.path.join(path, 'output_%s_%s' % (pseudo_material.uuid, uuid4()))
+    output_dir = os.path.join(path, 'output_%s_%s' % (material.uuid, uuid4()))
     print('Output directory :\t%s' % output_dir)
     os.makedirs(output_dir, exist_ok=True)
     filename = os.path.join(output_dir, '%s_loading.input' % adsorbate)
-    write_raspa_file(filename, pseudo_material.uuid, helium_void_fraction)
-    write_cif_file(pseudo_material, output_dir)
-    write_mixing_rules(pseudo_material, output_dir)
-    write_pseudo_atoms(pseudo_material, output_dir)
+    write_raspa_file(filename, material.uuid, helium_void_fraction)
+    write_cif_file(material, output_dir)
+    write_mixing_rules(material, output_dir)
+    write_pseudo_atoms(material, output_dir)
     write_force_field(output_dir)
     print("Date :\t%s" % datetime.now().date().isoformat())
     print("Time :\t%s" % datetime.now().time().isoformat())
-    print("Simulating %s loading in %s..." % (adsorbate, pseudo_material.uuid))
+    print("Simulating %s loading in %s..." % (adsorbate, material.uuid))
     while True:
         try:
             subprocess.run(
@@ -165,7 +165,7 @@ def run(run_id, pseudo_material, helium_void_fraction=None):
                 cwd = output_dir
             )
         
-            file_name_part = "output_%s" % (pseudo_material.uuid)
+            file_name_part = "output_%s" % (material.uuid)
             output_subdir = os.path.join(output_dir, 'Output', 'System_0')
             for file in os.listdir(output_subdir):
                 if file_name_part in file:

--- a/htsohm/simulation/helium_void_fraction.py
+++ b/htsohm/simulation/helium_void_fraction.py
@@ -61,7 +61,7 @@ def parse_output(output_file):
         print("\nVOID FRACTION :   %s\n" % (results['vf_helium_void_fraction']))
     return results
 
-def run(run_id, pseudo_material):
+def run(run_id, material):
     """Runs void fraction simulation.
 
     Args:
@@ -80,22 +80,22 @@ def run(run_id, pseudo_material):
         path = os.environ['SCRATCH']
     else:
         print('OUTPUT DIRECTORY NOT FOUND.')
-    output_dir = os.path.join(path, 'output_%s_%s' % (pseudo_material.uuid, uuid4()))
+    output_dir = os.path.join(path, 'output_%s_%s' % (material.uuid, uuid4()))
     print("Output directory :\t%s" % output_dir)
     os.makedirs(output_dir, exist_ok=True)
     filename = os.path.join(output_dir, "VoidFraction.input")
-    write_raspa_file(filename, pseudo_material.uuid)
-    write_cif_file(pseudo_material, output_dir)
-    write_mixing_rules(pseudo_material, output_dir)
-    write_pseudo_atoms(pseudo_material, output_dir)
+    write_raspa_file(filename, material.uuid)
+    write_cif_file(material, output_dir)
+    write_mixing_rules(material, output_dir)
+    write_pseudo_atoms(material, output_dir)
     write_force_field(output_dir)
     while True:
         try:
             print("Date :\t%s" % datetime.now().date().isoformat())
             print("Time :\t%s" % datetime.now().time().isoformat())
-            print("Calculating void fraction of %s..." % (pseudo_material.uuid))
+            print("Calculating void fraction of %s..." % (material.uuid))
             subprocess.run(['simulate', './VoidFraction.input'], check=True, cwd=output_dir)
-            filename = "output_%s_1.1.1_298.000000_0.data" % (pseudo_material.uuid)
+            filename = "output_%s_1.1.1_298.000000_0.data" % (material.uuid)
             output_file = os.path.join(output_dir, 'Output', 'System_0', filename)
             results = parse_output(output_file)
             shutil.rmtree(output_dir, ignore_errors=True)

--- a/htsohm/simulation/surface_area.py
+++ b/htsohm/simulation/surface_area.py
@@ -75,7 +75,7 @@ def parse_output(output_file):
         "%s\tm^2/cm^3"   % (results['sa_volumetric_surface_area']))
     return results
 
-def run(run_id, pseudo_material):
+def run(run_id, material):
     """Runs surface area simulation.
 
     Args:
@@ -94,22 +94,22 @@ def run(run_id, pseudo_material):
         path = os.environ['SCRATCH']
     else:
         print('OUTPUT DIRECTORY NOT FOUND.')
-    output_dir = os.path.join(path, 'output_%s_%s' % (pseudo_material.uuid, uuid4()))
+    output_dir = os.path.join(path, 'output_%s_%s' % (material.uuid, uuid4()))
     print("Output directory :\t%s" % output_dir)
     os.makedirs(output_dir, exist_ok=True)
     filename = os.path.join(output_dir, "SurfaceArea.input")
-    write_raspa_file(filename, pseudo_material.uuid)
-    write_cif_file(pseudo_material, output_dir)
-    write_mixing_rules(pseudo_material, output_dir)
-    write_pseudo_atoms(pseudo_material, output_dir)
+    write_raspa_file(filename, material.uuid)
+    write_cif_file(material, output_dir)
+    write_mixing_rules(material, output_dir)
+    write_pseudo_atoms(material, output_dir)
     write_force_field(output_dir)
     while True:
         try:
             print("Date :\t%s" % datetime.now().date().isoformat())
             print("Time :\t%s" % datetime.now().time().isoformat())
-            print("Calculating surface area of %s..." % (pseudo_material.uuid))
+            print("Calculating surface area of %s..." % (material.uuid))
             subprocess.run(['simulate', './SurfaceArea.input'], check=True, cwd=output_dir)
-            filename = "output_%s_1.1.1_298.000000_0.data" % (pseudo_material.uuid)
+            filename = "output_%s_1.1.1_298.000000_0.data" % (material.uuid)
             output_file = os.path.join(output_dir, 'Output', 'System_0', filename)
             results = parse_output(output_file)
             shutil.rmtree(output_dir, ignore_errors=True)

--- a/tests/test_material_files.py
+++ b/tests/test_material_files.py
@@ -2,11 +2,15 @@ from random import choice, random, randrange, uniform
 import pytest
 
 from htsohm.material_files import random_number_density
+from htsohm.db import Structure
 
 @pytest.fixture
 def LCs():
-    lattice_constants = {"a" : 1, "b" : 1, "c" : 1}
-    return lattice_constants
+    structure = Structure()
+    structure.lattice_constant_a = 1
+    structure.lattice_constant_b = 1
+    structure.lattice_constant_c = 1
+    return structure
 
 def test_number_density_bounds():
     assert random_number_density((100000, 100000), LCs()) == 100000


### PR DESCRIPTION
Added relational schemas for storing pseudomaterial structure data. These new tables include:
  - structures : stores material_id (foreign key), id (structure), and lattice constant values
  - atom_sites : stores atom-site positions and partial charges (if applicable)
  - lennard_jones : stores lennard-jones parameters for all atom-types

The use of this table eliminates the need for PseudoMaterial objects, as structure-data can simply be queried; additionally there is no need to dump structures to file, however, .cif-files are written to temporary directory a simulation-time.

Future work could move mutate and generate functions to Material class methods.